### PR TITLE
Added a check for null joinSets

### DIFF
--- a/src/main/java/com/theoryinpractise/coffeescript/CoffeeScriptCompilerMojo.java
+++ b/src/main/java/com/theoryinpractise/coffeescript/CoffeeScriptCompilerMojo.java
@@ -147,7 +147,8 @@ public class CoffeeScriptCompilerMojo extends AbstractMojo {
         };
 
         // Map joinsets
-        for (JoinSet joinSet : joinSets) {
+	if (joinSets != null) {
+          for (JoinSet joinSet : joinSets) {
 
             String description = String.format(
                     "joingset %s (containing %s)",
@@ -169,6 +170,7 @@ public class CoffeeScriptCompilerMojo extends AbstractMojo {
             File jsFileName = new File(outputDirectory, joinSet.getId() + ".js");
             coffeeSuppliers.put(jsFileName, new JoinSetSource(description, joinSetSupplier));
 
+          }
         }
 
         // Map remaining files


### PR DESCRIPTION
Hi, I added a check in the CoffeeScriptCompilerMojo at line 149 to see if the list of joinSets is null. When no joinSets configuration is specified, the plugin would crash with a NPE.
